### PR TITLE
binance_perpetual returns an error so default to kucoin

### DIFF
--- a/pages/data/download_candles/app.py
+++ b/pages/data/download_candles/app.py
@@ -14,7 +14,7 @@ c1, c2, c3, c4 = st.columns([2, 2, 2, 0.5])
 with c1:
     connector = st.selectbox("Exchange",
                              ["binance_perpetual", "binance", "gate_io", "gate_io_perpetual", "kucoin", "ascend_ex"],
-                             index=0)
+                             index=4)
     trading_pair = st.text_input("Trading Pair", value="BTC-USDT")
 with c2:
     interval = st.selectbox("Interval", options=["1m", "3m", "5m", "15m", "1h", "4h", "1d", "1s"])


### PR DESCRIPTION
Whenever following the ["Hummingbot Dashboard Tutorial"](http://localhost:8501/#watch-the-hummingbot-dashboard-tutorial) [video](https://youtu.be/7eHiMPRBQLQ?t=1239) the default values of `binance_perpetual`, `1m interval`, `2023/01/01` to `2023/01/02`, `BTC-USDT` fail to download candles (Ref. #51). 

[As mentioned](https://github.com/hummingbot/deploy/issues/51#issuecomment-2467314599), `kucoin` seems to work. 

This PR defaults to setting the `exchange` to `kucoin` in the drop down to "hide" the error. 