### PR TITLE
(fix) macOS setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -120,8 +120,8 @@ if [ -f "docker-compose.yml" ]; then
     cp docker-compose.yml docker-compose.yml.backup
     
     # Update the credentials using sed
-    sed -i "s/BACKEND_API_USERNAME=.*/BACKEND_API_USERNAME=$USERNAME/" docker-compose.yml
-    sed -i "s/BACKEND_API_PASSWORD=.*/BACKEND_API_PASSWORD=$PASSWORD/" docker-compose.yml
+    sed -i "" "s/BACKEND_API_USERNAME=.*/BACKEND_API_USERNAME=$USERNAME/" docker-compose.yml
+    sed -i "" "s/BACKEND_API_PASSWORD=.*/BACKEND_API_PASSWORD=$PASSWORD/" docker-compose.yml
     
     echo -e "${GREEN}✅ docker-compose.yml updated successfully!${NC}"
     echo -e "${BLUE}📋 Updated credentials:${NC} Username: $USERNAME, Password: $PASSWORD"


### PR DESCRIPTION
When trying to run setup.sh on macOS(15.6.1 (24G90)) I ran into the following issue:

```
nico@Nicos-MacBook-Air hummingbot % bash setup.sh
🚀 Hummingbot Deploy Setup

Config password [default: admin]: 
Dashboard username [default: admin]: 
Dashboard password [default: admin]: 

✅ Using sensible defaults for MQTT, Database, and other settings

📝 Creating .env file...
✅ .env file created successfully!

🔧 Updating docker-compose.yml with new credentials...
sed: 1: "docker-compose.yml": extra characters at the end of d command
```

The setup script would terminate right after this.

The fix is described in the first answer of [this stackoverflow post](https://stackoverflow.com/questions/26081375/bsd-sed-extra-characters-at-the-end-of-d-command).

I applied it and the deployment now works on macOS.
